### PR TITLE
Use explicit width for `srcSet` generation, allow generating srcSets without retina support

### DIFF
--- a/src/lib/UploadcareImage.ts
+++ b/src/lib/UploadcareImage.ts
@@ -232,14 +232,15 @@ export class UploadcareImage {
     };
 
     public srcSet = (width: number): string => {
-        if (this.width < width * 2) {
-            return '';
+        const doubleWidth = width * 2;
+        const src1x = this.resize(width).cdnUrl;
+        const src2x = this.resize(doubleWidth).cdnUrl;
+
+        if (this.width < doubleWidth) {
+            return `${src1x} ${width}w`;
         }
 
-        const src1x = this.resize(width).cdnUrl;
-        const src2x = this.resize(width * 2).cdnUrl;
-
-        return `${src1x} 1x, ${src2x} 2x`;
+        return `${src1x} ${width}w, ${src2x} ${doubleWidth}w`;
     };
 
     public toPrezlyStoragePayload = (): UploadedImage => ({


### PR DESCRIPTION
The previous implementation had two problems:

- Only generating srcSet string when a doubled resolution is available
- Only using `1x, 2x` syntax, which is intended for images that have a fixed width (which is not the case for Content Renderer)

This PR solves both issues, by using explicit width attributes in the `srcSet`. Retina displays are still support, as the browsers are smart enough to select an appropriate image size based on the device pixel ratio.
See https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images#how_do_you_create_responsive_images