### PR TITLE
[CARE-4715] Fix - Always apply the inline parameter to downloadUrl

### DIFF
--- a/src/lib/UploadcareImage.ts
+++ b/src/lib/UploadcareImage.ts
@@ -140,12 +140,7 @@ export class UploadcareImage {
         const downloadUrl = [
             UPLOADCARE_CDN_URL,
             this.uuid,
-            // Prepend a dash only if effects exist.
-            // It doesn't matter if there's a dash at the end of URL even if there are no effects,
-            // but it looks cleaner without it.
-            this.effects.length === 0
-                ? this.effects
-                : ['', ...this.effects, '/inline/no/'].join('-'),
+            ['', ...this.effects, '/inline/no/'].join('-'),
         ].join('/');
 
         return `${downloadUrl}${encodeURIComponent(this.filename)}`;


### PR DESCRIPTION
If the `effects` array was empty, the `inline` parameter was not applied. I'm not sure what was the intention behind the original logic, but the URL still looks nice and ends with the filename as it should.